### PR TITLE
Added fileDump attribute into __init__ of mmb()

### DIFF
--- a/interfaces.py
+++ b/interfaces.py
@@ -39,6 +39,8 @@ class mmb(): # macromolecule builder
         self.foldedSequence = 'foldedSequence_{}.pdb'.format(ind1)
 
         self.intervalLength = intervalLength
+        
+        self.fileDump = 'mmbFiles_%d'%self.ind1
 
     def generateCommandFile(self):
         copyfile(self.template, self.comFile)  # make command file


### PR DESCRIPTION
This would fix the issue of the system not recognizing fileDump as mentioned before. This was also included as an edit in the most recent run, so perhaps it would be a good idea to include it.