### PR TITLE
Added "initial" keyword to np.amax on line 107

### DIFF
--- a/interfaces.py
+++ b/interfaces.py
@@ -104,7 +104,7 @@ class mmb(): # macromolecule builder
                     scores.append(numerator/denominator)
 
         scores = np.asarray(scores)
-        self.foldFidelity = np.amax(scores)
+        self.foldFidelity = np.amax(scores, initial=0.0)
 
     def run(self):
         self.generateCommandFile()


### PR DESCRIPTION
This avoids the ValueError: zero-size array to reduction operation maximum which has no identity.